### PR TITLE
Propagating Questions to MetricFF and the Reward Function

### DIFF
--- a/code/model/Learner.cpp
+++ b/code/model/Learner.cpp
@@ -334,9 +334,9 @@ double SubgoalLearner::ComputeReward (SubgoalSequenceState& _rState)
 	ITERATE (Subgoal_dq_t, _rState.p_Sequence->dq_Subgoals, ite)
 	{
 		Subgoal& rSubgoal = *ite;
-        if (rSubgoal.b_isQuestion)
-            continue;
-        if (SEQUENCE_END == rSubgoal.i_SequenceEnd)
+		if (rSubgoal.b_isQuestion)
+            		continue;
+        	if (SEQUENCE_END == rSubgoal.i_SequenceEnd)
 			continue;
 
 		if (po_ff_code_change_required == rSubgoal.e_PlanningOutcome)
@@ -758,7 +758,7 @@ void SubgoalLearner::Iterate (int _iIteration, bool _bTestMode)
 	pthread_mutex_unlock (&mtx_WaitForSequences);
 
 
-    // TODO: Test threading and semaphores still work as expected
+        // TODO: Test threading and semaphores still work as expected
 	// condition wait for sequences to complete...
 	pthread_mutex_lock (&mtx_WaitForSequences);
 	pthread_cond_wait (&cv_WaitForSequences, &mtx_WaitForSequences);

--- a/run_gdb.sh
+++ b/run_gdb.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 ./run_cache.sh &
 ./run_client.sh &
-gdb bin/text_guided_planner
+cgdb bin/text_guided_planner


### PR DESCRIPTION
# This is a working branch for #4

This isn't final or fully tested. Still investigating if i'm tackling the reward problem correctly.
# What this does
- Skip sending questions to MetricFF
- Do not count completion of questions (trivial) as part of the reward
# Concerns
- Am I using RL correctly
- Do I mess up some of the `mutex` stuff that handles concurrency by not having send the questions
  -Current Hypothesis: Probably. Will test soon
# Other changes
- Changed to cgdb, because :cupid: 
- My editor auto truncated spaced after comments. I'm sorry. 
# Fun facts
- This was created from a plane
